### PR TITLE
Npa

### DIFF
--- a/src/it/scala/com/ing/wbaa/gargoyle/sts/StsServiceItTest.scala
+++ b/src/it/scala/com/ing/wbaa/gargoyle/sts/StsServiceItTest.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.Uri.{Authority, Host}
 import akka.stream.ActorMaterializer
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService
 import com.amazonaws.services.securitytoken.model.{AWSSecurityTokenServiceException, AssumeRoleWithWebIdentityRequest, GetSessionTokenRequest}
-import com.ing.wbaa.gargoyle.sts.config.{GargoyleHttpSettings, GargoyleKeycloakSettings, GargoyleStsSettings}
+import com.ing.wbaa.gargoyle.sts.config.{GargoyleHttpSettings, GargoyleKeycloakSettings, GargoyleNPASettings, GargoyleStsSettings}
 import com.ing.wbaa.gargoyle.sts.data.aws._
 import com.ing.wbaa.gargoyle.sts.helper.{KeycloackToken, OAuth2TokenRequest}
 import com.ing.wbaa.gargoyle.sts.keycloak.KeycloakTokenVerifier
@@ -54,6 +54,8 @@ class StsServiceItTest extends AsyncWordSpec with DiagrammedAssertions
       }
 
       override protected[this] def stsSettings: GargoyleStsSettings = GargoyleStsSettings(testSystem)
+
+      override protected[this] def gargoyleNPASettings: GargoyleNPASettings = GargoyleNPASettings(testSystem)
 
       override def generateAwsCredential: AwsCredential = AwsCredential(
         AwsAccessKey("accesskey" + Random.alphanumeric.take(32).mkString),

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,4 +20,6 @@ gargoyle {
         defaultTokenSessionHours = 8
         maxTokenSessionHours = 24
     }
+
+    npa: []
 }

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/Server.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/Server.scala
@@ -1,7 +1,7 @@
 package com.ing.wbaa.gargoyle.sts
 
 import akka.actor.ActorSystem
-import com.ing.wbaa.gargoyle.sts.config.{ GargoyleHttpSettings, GargoyleKeycloakSettings, GargoyleStsSettings }
+import com.ing.wbaa.gargoyle.sts.config.{ GargoyleHttpSettings, GargoyleKeycloakSettings, GargoyleNPASettings, GargoyleStsSettings }
 import com.ing.wbaa.gargoyle.sts.keycloak.KeycloakTokenVerifier
 import com.ing.wbaa.gargoyle.sts.service.UserTokenDbService
 
@@ -14,5 +14,7 @@ object Server extends App {
     override protected[this] def keycloakSettings: GargoyleKeycloakSettings = GargoyleKeycloakSettings(system)
 
     override protected[this] def stsSettings: GargoyleStsSettings = GargoyleStsSettings(system)
+
+    override protected[this] def gargoyleNPASettings: GargoyleNPASettings = GargoyleNPASettings(system)
   }.startup
 }

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/api/STSApi.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/api/STSApi.scala
@@ -34,7 +34,7 @@ trait STSApi extends LazyLogging with TokenXML {
     (parameters(input) | formField(input)).tmap(t => t.copy(parseDurationSeconds(t._1)))
   }
 
-  protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroup: Option[UserGroup]): Future[AwsCredentialWithToken]
+  protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroup: Option[UserAssumedGroup]): Future[AwsCredentialWithToken]
 
   // Keycloak
   protected[this] def verifyAuthenticationToken(token: BearerToken): Option[AuthenticationUserInfo]

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/api/UserApi.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/api/UserApi.scala
@@ -12,13 +12,9 @@ import scala.concurrent.Future
 
 trait UserApi extends LazyLogging {
 
-  protected[this] def isNPAActive(awsAccessKey: AwsAccessKey): Future[Boolean]
+  protected[this] def isCredentialActive(awsAccessKey: AwsAccessKey, awsSessionToken: Option[AwsSessionToken]): Future[Option[STSUserInfo]]
 
-  protected[this] def isTokenActive(awsAccessKey: AwsAccessKey, awsSessionToken: AwsSessionToken): Future[Boolean]
-
-  protected[this] def getUserWithAssumedGroups(awsAccessKey: AwsAccessKey, awsSessionToken: AwsSessionToken): Future[Option[STSUserInfo]]
-
-  val userRoutes: Route = verifyNPAUser ~ verifyUser ~ getUser
+  val userRoutes: Route = isCredentialActive
 
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
   import spray.json.DefaultJsonProtocol._
@@ -28,61 +24,24 @@ trait UserApi extends LazyLogging {
 
   implicit val userInfoJsonFormat: RootJsonFormat[UserInfoToReturn] = jsonFormat4(UserInfoToReturn)
 
-  def verifyNPAUser: Route = logRequestResult("debug") {
-    path("isNPACredentialActive") {
-      get {
-        parameter('accessKey) { accessKey =>
-          onSuccess(isNPAActive(AwsAccessKey(accessKey))) { isActive =>
-            val result = if (isActive) {
-              logger.info("isNPACredentialActive ok for accessKey={}", accessKey)
-              StatusCodes.OK
-            } else {
-              logger.info("isNPACredentialActive forbidden for accessKey={}", accessKey)
-              StatusCodes.Forbidden
-            }
-            complete(result)
-          }
-        }
-      }
-    }
-  }
-
-  def verifyUser: Route = logRequestResult("debug") {
+  def isCredentialActive: Route = logRequestResult("debug") {
     path("isCredentialActive") {
       get {
-        parameters(("accessKey", "sessionToken")) { (accessKey, sessionToken) =>
-          onSuccess(isTokenActive(AwsAccessKey(accessKey), AwsSessionToken(sessionToken))) { isActive =>
-            val result = if (isActive) {
-              logger.info("isCredentialActive ok for accessKey={}, sessionToken={}", accessKey, sessionToken)
-              StatusCodes.OK
-            } else {
-              logger.info("isCredentialActive forbidden for accessKey={}, sessionToken={}", accessKey, sessionToken)
-              StatusCodes.Forbidden
-            }
-            complete(result)
-          }
-        }
-      }
-    }
-  }
+        parameters(('accessKey, 'sessionToken.?)) { (accessKey, sessionToken) =>
+          onSuccess(isCredentialActive(AwsAccessKey(accessKey), sessionToken.map(AwsSessionToken))) {
 
-  def getUser: Route = logRequestResult("debug") {
-    path("userInfo") {
-      get {
-        parameters(('accessKey, 'sessionToken)) {
-          (accessKey, sessionToken) =>
-            onSuccess(getUserWithAssumedGroups(AwsAccessKey(accessKey), AwsSessionToken(sessionToken))) {
-              case Some(userInfo) =>
-                logger.info("user info ok for accessKey={}", accessKey)
-                complete(UserInfoToReturn(
-                  userInfo.userName.value,
-                  userInfo.assumedGroup.map(_.value),
-                  userInfo.awsAccessKey.value,
-                  userInfo.awsSecretKey.value))
-              case _ =>
-                logger.info("user info not found for accessKey={}", accessKey)
-                complete(StatusCodes.NotFound)
-            }
+            case Some(userInfo) =>
+              logger.info("isCredentialActive ok for accessKey={}, sessionToken={}", accessKey, sessionToken)
+              complete((StatusCodes.OK, UserInfoToReturn(
+                userInfo.userName.value,
+                userInfo.assumedGroup.map(_.value),
+                userInfo.awsAccessKey.value,
+                userInfo.awsSecretKey.value)))
+
+            case None =>
+              logger.info("isCredentialActive forbidden for accessKey={}, sessionToken={}", accessKey, sessionToken)
+              complete(StatusCodes.Forbidden)
+          }
         }
       }
     }

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/api/UserApi.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/api/UserApi.scala
@@ -20,7 +20,7 @@ trait UserApi extends LazyLogging {
   import spray.json.DefaultJsonProtocol._
 
   // TODO: remove this and properly parse userinfo
-  case class UserInfoToReturn(userName: String, userGroup: Option[String], accessKey: String, secretKey: String)
+  case class UserInfoToReturn(userName: String, userAssumedGroup: Option[String], accessKey: String, secretKey: String)
 
   implicit val userInfoJsonFormat: RootJsonFormat[UserInfoToReturn] = jsonFormat4(UserInfoToReturn)
 

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/config/GargoyleNPASettings.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/config/GargoyleNPASettings.scala
@@ -1,0 +1,24 @@
+package com.ing.wbaa.gargoyle.sts.config
+
+import akka.actor.{ ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
+import com.typesafe.config.Config
+
+import scala.collection.mutable
+
+// TODO Remove all of this, NPAs should be set in the DB directly or in Keycloak if possible
+class GargoyleNPASettings(config: Config) extends Extension {
+  import scala.collection.JavaConverters._
+
+  val gargoyleNPAList: List[mutable.Map[String, String]] =
+    config.getList("gargoyle.npa").unwrapped().asScala.toList
+      .map { someConfig =>
+        someConfig.asInstanceOf[java.util.Map[String, String]].asScala
+      }
+}
+
+object GargoyleNPASettings extends ExtensionId[GargoyleNPASettings] with ExtensionIdProvider {
+  override def createExtension(system: ExtendedActorSystem): GargoyleNPASettings = new GargoyleNPASettings(system.settings.config)
+
+  override def lookup(): ExtensionId[GargoyleNPASettings] = GargoyleNPASettings
+}
+

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/data/AuthenticationUserInfo.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/data/AuthenticationUserInfo.scala
@@ -2,6 +2,8 @@ package com.ing.wbaa.gargoyle.sts.data
 
 case class AuthenticationTokenId(value: String) extends AnyVal
 
+case class UserGroup(value: String) extends AnyVal
+
 case class AuthenticationUserInfo(
     userName: UserName,
     userGroups: Set[UserGroup],

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/data/STSUserInfo.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/data/STSUserInfo.scala
@@ -4,10 +4,10 @@ import com.ing.wbaa.gargoyle.sts.data.aws.{ AwsAccessKey, AwsSecretKey }
 
 case class UserName(value: String) extends AnyVal
 
-case class UserGroup(value: String) extends AnyVal
+case class UserAssumedGroup(value: String) extends AnyVal
 
 case class STSUserInfo(
     userName: UserName,
-    assumedGroup: Option[UserGroup],
+    assumedGroup: Option[UserAssumedGroup],
     awsAccessKey: AwsAccessKey,
     awsSecretKey: AwsSecretKey)

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/service/UserTokenDbService.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/service/UserTokenDbService.scala
@@ -2,7 +2,7 @@ package com.ing.wbaa.gargoyle.sts.service
 
 import java.time.Instant
 
-import com.ing.wbaa.gargoyle.sts.data.{ UserGroup, STSUserInfo, UserName }
+import com.ing.wbaa.gargoyle.sts.data.{ STSUserInfo, UserAssumedGroup, UserName }
 import com.ing.wbaa.gargoyle.sts.data.aws._
 import com.ing.wbaa.gargoyle.sts.service.db.{ TokenDb, UserDb }
 import com.typesafe.scalalogging.LazyLogging
@@ -17,7 +17,7 @@ trait UserTokenDbService extends LazyLogging with TokenDb with UserDb {
   /**
    * Retrieve or generate Credentials and generate a new Session
    */
-  protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroups: Option[UserGroup]): Future[AwsCredentialWithToken] =
+  protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroups: Option[UserAssumedGroup]): Future[AwsCredentialWithToken] =
     for {
       awsCredential <- getOrGenerateAwsCredential(userName)
       awsSession <- getNewAwsSession(userName, duration, assumedGroups)

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDb.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDb.scala
@@ -28,8 +28,8 @@ trait TokenDb extends TokenGeneration with LazyLogging {
     )
   }
 
-  protected[this] def getUserNameAndTokenExpiration(awsSessionToken: AwsSessionToken): Future[Option[(UserName, AwsSessionTokenExpiration)]] = synchronized {
-    Future.successful(awsCredentialStore.get(awsSessionToken).map(e => (e._2, e._1)))
+  protected[this] def getTokenExpiration(awsSessionToken: AwsSessionToken): Future[Option[AwsSessionTokenExpiration]] = synchronized {
+    Future.successful(awsCredentialStore.get(awsSessionToken).map(e => e._1))
   }
 
   /**

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDb.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDb.scala
@@ -1,6 +1,6 @@
 package com.ing.wbaa.gargoyle.sts.service.db
 
-import com.ing.wbaa.gargoyle.sts.data.{ UserGroup, UserName }
+import com.ing.wbaa.gargoyle.sts.data.{ UserAssumedGroup, UserName }
 import com.ing.wbaa.gargoyle.sts.data.aws.{ AwsSession, AwsSessionToken, AwsSessionTokenExpiration }
 import com.typesafe.scalalogging.LazyLogging
 
@@ -16,13 +16,13 @@ trait TokenDb extends TokenGeneration with LazyLogging {
   implicit protected[this] def executionContext: ExecutionContext
 
   // TODO: Move this store to an actual DB
-  private[this] val awsCredentialStore = mutable.Map[AwsSessionToken, (AwsSessionTokenExpiration, UserName, Option[UserGroup])]()
+  private[this] val awsCredentialStore = mutable.Map[AwsSessionToken, (AwsSessionTokenExpiration, UserName, Option[UserAssumedGroup])]()
 
   private[this] def credentialExists(awsSessionToken: AwsSessionToken): Boolean = synchronized {
     awsCredentialStore.get(awsSessionToken).isDefined
   }
 
-  protected[this] def getAssumedGroupsForToken(awsSessionToken: AwsSessionToken): Future[Option[UserGroup]] = synchronized {
+  protected[this] def getAssumedGroupsForToken(awsSessionToken: AwsSessionToken): Future[Option[UserAssumedGroup]] = synchronized {
     Future.successful(
       awsCredentialStore.get(awsSessionToken).flatMap(_._3)
     )
@@ -41,7 +41,7 @@ trait TokenDb extends TokenGeneration with LazyLogging {
    * @param assumedUserGroup Group this sessiontoken gives you access to.
    * @return awsCredential if credential is not a duplicated and added successfully
    */
-  protected[this] def addCredential(awsSession: AwsSession, userName: UserName, assumedUserGroup: Option[UserGroup]): Future[Option[AwsSession]] =
+  protected[this] def addCredential(awsSession: AwsSession, userName: UserName, assumedUserGroup: Option[UserAssumedGroup]): Future[Option[AwsSession]] =
     Future.successful(
       if (credentialExists(awsSession.sessionToken)) None
       else synchronized {
@@ -53,7 +53,7 @@ trait TokenDb extends TokenGeneration with LazyLogging {
   /**
    * Retrieve a new Aws Session, encoded with it are the groups assumed with this token
    */
-  protected[this] def getNewAwsSession(userName: UserName, duration: Option[Duration], assumedGroups: Option[UserGroup]): Future[AwsSession] = {
+  protected[this] def getNewAwsSession(userName: UserName, duration: Option[Duration], assumedGroups: Option[UserAssumedGroup]): Future[AwsSession] = {
     val newAwsSession = generateAwsSession(duration)
     addCredential(newAwsSession, userName, assumedGroups)
       .flatMap {

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDb.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDb.scala
@@ -27,7 +27,7 @@ trait UserDb extends TokenGeneration with LazyLogging {
     )
   )
 
-  protected[this] def getAwsCredential(userName: UserName): Future[Option[AwsCredential]] = synchronized {
+  private[this] def getAwsCredential(userName: UserName): Future[Option[AwsCredential]] = synchronized {
     Future.successful(userStore.get(userName).map(_.awsCredential))
   }
 

--- a/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDb.scala
+++ b/src/main/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDb.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
- * Serves a table with a mapping from "username" -> "secretkey", "accesskey"
+ * Serves a table with a mapping from "username" -> "secretkey", "accesskey", "isNPA"
  * Some Remarks:
  *   - UID in S3 == username
  *   - usernames and accesskeys should be unique
@@ -18,10 +18,17 @@ trait UserDb extends TokenGeneration with LazyLogging {
   implicit protected[this] def executionContext: ExecutionContext
 
   // TODO: Move this store to an actual DB
-  private[this] val userStore = mutable.Map[UserName, AwsCredential]()
+  private[this] case class DbValue(awsCredential: AwsCredential, isNpa: Boolean)
+
+  private[this] val userStore = mutable.Map[UserName, DbValue](
+    UserName("ranger") -> DbValue(
+      AwsCredential(AwsAccessKey("ranger6QeHX2dLdyGYIAK4iE4R7kSUue"), AwsSecretKey("3Zl8cBAkykUQLOYGjmI38Txi02TFdEAv")),
+      true
+    )
+  )
 
   protected[this] def getAwsCredential(userName: UserName): Future[Option[AwsCredential]] = synchronized {
-    Future.successful(userStore.get(userName))
+    Future.successful(userStore.get(userName).map(_.awsCredential))
   }
 
   /**
@@ -30,16 +37,22 @@ trait UserDb extends TokenGeneration with LazyLogging {
    */
   protected[this] def addToUserStore(userName: UserName, awsCredential: AwsCredential): Future[Option[AwsCredential]] = synchronized {
     Future.successful(
-      if (userStore.values.map(_.accessKey).toList.contains(awsCredential.accessKey)) None
+      if (userStore.values.map(_.awsCredential.accessKey).toList.contains(awsCredential.accessKey)) None
       else {
-        userStore.put(userName, awsCredential)
+        userStore.put(userName, DbValue(awsCredential, false))
         Some(awsCredential)
       }
     )
   }
 
-  protected[this] def getUserAndSecretKey(awsAccessKey: AwsAccessKey): Future[Option[(UserName, AwsSecretKey)]] = synchronized {
-    val matches = userStore.filter(_._2.accessKey == awsAccessKey).map(e => (e._1, e._2.secretKey)).toList
+  /**
+   * @param awsAccessKey Aws AccessKey
+   * @return username/secretKey/isNPA
+   */
+  protected[this] def getUserSecretKeyAndIsNPA(awsAccessKey: AwsAccessKey): Future[Option[(UserName, AwsSecretKey, Boolean)]] = synchronized {
+    val matches = userStore
+      .filter(_._2.awsCredential.accessKey == awsAccessKey)
+      .map(e => (e._1, e._2.awsCredential.secretKey, e._2.isNpa)).toList
 
     Future.successful {
       if (matches.length == 1) Some(matches.head)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,9 @@
+gargoyle {
+    npa: [
+        {
+            "username": "ranger",
+            "accesskey" : "ranger6QeHX2dLdyGYIAK4iE4R7kSUue",
+            "secretkey" : "3Zl8cBAkykUQLOYGjmI38Txi02TFdEAv"
+        }
+    ]
+}

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/api/STSApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/api/STSApiTest.scala
@@ -32,7 +32,7 @@ class STSApiTest extends WordSpec with DiagrammedAssertions with ScalatestRouteT
         case _       => None
       }
 
-    override protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroup: Option[UserGroup]): Future[AwsCredentialWithToken] = {
+    override protected[this] def getAwsCredentialWithToken(userName: UserName, duration: Option[Duration], assumedGroup: Option[UserAssumedGroup]): Future[AwsCredentialWithToken] = {
       Future.successful(AwsCredentialWithToken(
         AwsCredential(
           AwsAccessKey("accesskey"),

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/api/UserApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/api/UserApiTest.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{ MissingQueryParamRejection, Route }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.ing.wbaa.gargoyle.sts.data.aws.{ AwsAccessKey, AwsSecretKey, AwsSessionToken }
-import com.ing.wbaa.gargoyle.sts.data.{ STSUserInfo, UserGroup, UserName }
+import com.ing.wbaa.gargoyle.sts.data.{ STSUserInfo, UserAssumedGroup, UserName }
 import org.scalatest.{ BeforeAndAfterAll, DiagrammedAssertions, WordSpec }
 
 import scala.concurrent.Future
@@ -16,7 +16,7 @@ class UserApiTest extends WordSpec
 
   trait testUserApi extends UserApi {
     override def isCredentialActive(awsAccessKey: AwsAccessKey, awsSessionToken: Option[AwsSessionToken]): Future[Option[STSUserInfo]] =
-      Future.successful(Some(STSUserInfo(UserName("username"), Some(UserGroup("usergroup")), AwsAccessKey("a"), AwsSecretKey("s"))))
+      Future.successful(Some(STSUserInfo(UserName("username"), Some(UserAssumedGroup("usergroup")), AwsAccessKey("a"), AwsSecretKey("s"))))
   }
 
   private[this] val testRoute: Route = new testUserApi {}.userRoutes

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/api/UserApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/api/UserApiTest.scala
@@ -28,7 +28,7 @@ class UserApiTest extends WordSpec
         Get(s"/isCredentialActive?accessKey=accesskey&sessionToken=sessionToken") ~> testRoute ~> check {
           assert(status == StatusCodes.OK)
           val response = responseAs[String]
-          assert(response == """{"userName":"username","userGroup":"usergroup","accessKey":"a","secretKey":"s"}""")
+          assert(response == """{"userName":"username","userAssumedGroup":"usergroup","accessKey":"a","secretKey":"s"}""")
         }
       }
 

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/data/aws/AwsRoleArnTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/data/aws/AwsRoleArnTest.scala
@@ -1,6 +1,6 @@
 package com.ing.wbaa.gargoyle.sts.data.aws
 
-import com.ing.wbaa.gargoyle.sts.data.{ AuthenticationTokenId, AuthenticationUserInfo, UserGroup, UserName }
+import com.ing.wbaa.gargoyle.sts.data._
 import org.scalatest.WordSpec
 
 class AwsRoleArnTest extends WordSpec {
@@ -15,7 +15,7 @@ class AwsRoleArnTest extends WordSpec {
           .getGroupUserCanAssume(
             AuthenticationUserInfo(UserName(""), Set(UserGroup(testGroup)), AuthenticationTokenId(""))
           )
-        assert(result.contains(UserGroup(testGroup)))
+        assert(result.contains(UserAssumedGroup(testGroup)))
       }
 
       "could not parse arn, invalid ARN" in {

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/UserTokenDbServiceTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/UserTokenDbServiceTest.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorSystem
 import com.ing.wbaa.gargoyle.sts.config.GargoyleStsSettings
 import com.ing.wbaa.gargoyle.sts.data.aws._
-import com.ing.wbaa.gargoyle.sts.data.{ UserGroup, UserName }
+import com.ing.wbaa.gargoyle.sts.data.{ UserAssumedGroup, UserName }
 import org.scalatest.{ AsyncWordSpec, DiagrammedAssertions }
 
 import scala.concurrent.ExecutionContext
@@ -23,7 +23,7 @@ class UserTokenDbServiceTest extends AsyncWordSpec with DiagrammedAssertions wit
   private class TestObject {
     val userName: UserName = UserName(Random.alphanumeric.take(32).mkString)
     val duration: Duration = Duration(2, TimeUnit.HOURS)
-    val assumedUserGroup: Option[UserGroup] = Some(UserGroup("group"))
+    val assumedUserGroup: Option[UserAssumedGroup] = Some(UserAssumedGroup("group"))
   }
 
   "User token service" should {

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/UserTokenDbServiceTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/UserTokenDbServiceTest.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
-import com.ing.wbaa.gargoyle.sts.config.GargoyleStsSettings
+import com.ing.wbaa.gargoyle.sts.config.{ GargoyleNPASettings, GargoyleStsSettings }
 import com.ing.wbaa.gargoyle.sts.data.aws._
 import com.ing.wbaa.gargoyle.sts.data.{ UserAssumedGroup, UserName }
 import org.scalatest.{ AsyncWordSpec, DiagrammedAssertions }
@@ -19,6 +19,7 @@ class UserTokenDbServiceTest extends AsyncWordSpec with DiagrammedAssertions wit
 
   override implicit def executionContext: ExecutionContext = testSystem.dispatcher
   override protected[this] def stsSettings: GargoyleStsSettings = GargoyleStsSettings(testSystem)
+  override protected[this] def gargoyleNPASettings: GargoyleNPASettings = GargoyleNPASettings(testSystem)
 
   private class TestObject {
     val userName: UserName = UserName(Random.alphanumeric.take(32).mkString)

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDbTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDbTest.scala
@@ -71,13 +71,13 @@ class TokenDbTest extends AsyncWordSpec with TokenDb with PrivateMethodTester {
     "getUserNameAndTokenExpiration" that {
       "token is not present" in {
         val testObject = new TestObject
-        getUserNameAndTokenExpiration(testObject.testSession.sessionToken).map(t => assert(t.isEmpty))
+        getTokenExpiration(testObject.testSession.sessionToken).map(t => assert(t.isEmpty))
       }
 
       "token is present" in {
         val testObject = new TestObject
         getNewAwsSession(testObject.testUserName, None, None).flatMap { testSession =>
-          getUserNameAndTokenExpiration(testSession.sessionToken).map(t => assert(t.contains((testObject.testUserName, testSession.expiration))))
+          getTokenExpiration(testSession.sessionToken).map(t => assert(t.contains(testSession.expiration)))
         }
       }
     }

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDbTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/TokenDbTest.scala
@@ -3,7 +3,7 @@ package com.ing.wbaa.gargoyle.sts.service.db
 import akka.actor.ActorSystem
 import com.ing.wbaa.gargoyle.sts.config.GargoyleStsSettings
 import com.ing.wbaa.gargoyle.sts.data.aws.AwsSession
-import com.ing.wbaa.gargoyle.sts.data.{ UserGroup, UserName }
+import com.ing.wbaa.gargoyle.sts.data.{ UserAssumedGroup, UserName }
 import org.scalatest.{ AsyncWordSpec, PrivateMethodTester }
 
 import scala.util.Random
@@ -18,7 +18,7 @@ class TokenDbTest extends AsyncWordSpec with TokenDb with PrivateMethodTester {
 
     val testSession: AwsSession = generateAwsSession(None)
     val testUserName: UserName = UserName(Random.alphanumeric.take(32).mkString)
-    val testAssumedUserGroup: Option[UserGroup] = Some(UserGroup(Random.alphanumeric.take(32).mkString))
+    val testAssumedUserGroup: Option[UserAssumedGroup] = Some(UserAssumedGroup(Random.alphanumeric.take(32).mkString))
   }
 
   "TokenDbTest" should {

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDbTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDbTest.scala
@@ -44,20 +44,6 @@ class UserDbTest extends AsyncWordSpec with UserDb with TokenGeneration with Pri
       }
     }
 
-    "get AwsCredential" that {
-      "exists" in {
-        val testObject = new TestObject
-        getOrGenerateAwsCredential(testObject.userName).flatMap { testCred =>
-          getAwsCredential(testObject.userName).map(c => assert(c.contains(testCred)))
-        }
-      }
-
-      "does not exist" in {
-        val testObject = new TestObject
-        getAwsCredential(testObject.userName).map(c => assert(c.isEmpty))
-      }
-    }
-
     "get User" that {
       "exists with accesskey" in {
         val testObject = new TestObject

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDbTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDbTest.scala
@@ -62,13 +62,13 @@ class UserDbTest extends AsyncWordSpec with UserDb with TokenGeneration with Pri
       "exists with accesskey" in {
         val testObject = new TestObject
         getOrGenerateAwsCredential(testObject.userName).flatMap { testCred =>
-          getUserAndSecretKey(testCred.accessKey).map(c => assert(c.contains((testObject.userName, testCred.secretKey))))
+          getUserSecretKeyAndIsNPA(testCred.accessKey).map(c => assert(c.contains((testObject.userName, testCred.secretKey, false))))
         }
       }
 
       "doesn't exist with accesskey" in {
         val testObject = new TestObject
-        getUserAndSecretKey(testObject.cred.accessKey).map(c => assert(c.isEmpty))
+        getUserSecretKeyAndIsNPA(testObject.cred.accessKey).map(c => assert(c.isEmpty))
       }
     }
   }

--- a/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDbTest.scala
+++ b/src/test/scala/com/ing/wbaa/gargoyle/sts/service/db/UserDbTest.scala
@@ -1,7 +1,7 @@
 package com.ing.wbaa.gargoyle.sts.service.db
 
 import akka.actor.ActorSystem
-import com.ing.wbaa.gargoyle.sts.config.GargoyleStsSettings
+import com.ing.wbaa.gargoyle.sts.config.{ GargoyleNPASettings, GargoyleStsSettings }
 import com.ing.wbaa.gargoyle.sts.data.UserName
 import com.ing.wbaa.gargoyle.sts.data.aws.AwsCredential
 import org.scalatest.{ AsyncWordSpec, PrivateMethodTester }
@@ -12,6 +12,7 @@ class UserDbTest extends AsyncWordSpec with UserDb with TokenGeneration with Pri
   val testSystem: ActorSystem = ActorSystem.create("test-system")
 
   override val stsSettings: GargoyleStsSettings = GargoyleStsSettings(testSystem)
+  override protected[this] val gargoyleNPASettings: GargoyleNPASettings = GargoyleNPASettings(testSystem)
 
   private class TestObject {
     val cred: AwsCredential = generateAwsCredential


### PR DESCRIPTION
- Support NPAs by making sessiontokens optional (when no sessiontoken is given, account should be flagged as NPA in DB)
- Combine endpoints for getting UserInfo and Verifying credentials. These commands are always done together and require the same parameters. AWS also has an endpoint that does these 2 things at once.
- Rename UserGroup to UserAssumedGroup to make very explicit we're talking not about groups the user owns in Keycloak, but the one he is currently (trying) to assume